### PR TITLE
update: increase waitFor timeout to 5000ms

### DIFF
--- a/testlib/src/utils.ts
+++ b/testlib/src/utils.ts
@@ -2,7 +2,7 @@ export async function wait(delay: number) {
     return new Promise((resolve) => setTimeout(resolve, delay));
 }
 
-export async function waitFor(func: () => boolean, timeout = 2000, interval = 0): Promise<void> {
+export async function waitFor(func: () => boolean, timeout = 5000, interval = 0): Promise<void> {
     const start = Date.now();
     while(true) {
         if (func()) return;


### PR DESCRIPTION
Slower PCs (Especially on HDD) tend to have slower load times, increasing timeout can make this function not to fail