### PR TITLE
Optimize exists checks in pools

### DIFF
--- a/bindings/src/client/entities/Blip.js
+++ b/bindings/src/client/entities/Blip.js
@@ -1,6 +1,6 @@
 import * as alt from 'alt-client';
 import mp from '../../shared/mp.js';
-import { ClientPool } from '../ClientPool.js';
+import { ClientPool } from '../pools/ClientPool.js';
 import { _WorldObject } from './WorldObject.js';
 import {EntityGetterView} from '../../shared/pools/EntityGetterView';
 import * as natives from 'natives';

--- a/bindings/src/client/entities/Browser.js
+++ b/bindings/src/client/entities/Browser.js
@@ -1,6 +1,6 @@
 import * as alt from 'alt-client';
 import mp from '../../shared/mp.js';
-import {ClientPool} from '../ClientPool.js';
+import {ClientPool} from '../pools/ClientPool.js';
 import {_BaseObject} from './BaseObject.js';
 import {EntityGetterView} from '../../shared/pools/EntityGetterView';
 import {emitServerInternal} from '../clientUtils';

--- a/bindings/src/client/entities/Camera.js
+++ b/bindings/src/client/entities/Camera.js
@@ -2,7 +2,7 @@ import * as alt from 'alt-client';
 import * as natives from 'natives';
 import mp from '../../shared/mp.js';
 import { rotToDir } from '../../shared/utils';
-import { ClientPool } from '../ClientPool';
+import { ClientPool } from '../pools/ClientPool';
 import {EntityStoreView} from '../../shared/pools/EntityStoreView';
 
 const view = new EntityStoreView();

--- a/bindings/src/client/entities/Checkpoint.js
+++ b/bindings/src/client/entities/Checkpoint.js
@@ -1,6 +1,6 @@
 import * as alt from 'alt-client';
 import mp from '../../shared/mp.js';
-import {ClientPool} from '../ClientPool.js';
+import {ClientPool} from '../pools/ClientPool.js';
 import {_BaseObject} from './BaseObject.js';
 import {EntityGetterView} from '../../shared/pools/EntityGetterView';
 import {internalName, mpDimensionToAlt} from '../../shared/utils';

--- a/bindings/src/client/entities/Colshape.js
+++ b/bindings/src/client/entities/Colshape.js
@@ -1,6 +1,6 @@
 import * as alt from 'alt-client';
 import mp from '../../shared/mp.js';
-import { ClientPool } from '../ClientPool.js';
+import { ClientPool } from '../pools/ClientPool.js';
 import { _Entity } from './Entity';
 import { _WorldObject } from './WorldObject';
 import { _BaseObject } from './BaseObject';

--- a/bindings/src/client/entities/Marker.js
+++ b/bindings/src/client/entities/Marker.js
@@ -1,6 +1,6 @@
 import * as alt from 'alt-client';
 import mp from '../../shared/mp.js';
-import {ClientPool} from '../ClientPool.js';
+import {ClientPool} from '../pools/ClientPool.js';
 import {_Entity} from './Entity';
 import {deg2rad, internalName, mpDimensionToAlt} from 'shared/utils';
 import {EntityGetterView} from '../../shared/pools/EntityGetterView';

--- a/bindings/src/client/entities/Object.js
+++ b/bindings/src/client/entities/Object.js
@@ -2,7 +2,7 @@ import mp from '../../shared/mp';
 import * as alt from 'alt-client';
 import * as natives from 'natives';
 import {_Entity} from './Entity';
-import { ClientPool } from '../ClientPool';
+import { ClientPool } from '../pools/ClientPool';
 import {EntityStoreView} from '../../shared/pools/EntityStoreView';
 import {EntityMixedView} from '../../shared/pools/EntityMixedView';
 import {EntityGetterView} from '../../shared/pools/EntityGetterView';

--- a/bindings/src/client/entities/Ped.js
+++ b/bindings/src/client/entities/Ped.js
@@ -1,6 +1,6 @@
 import * as alt from 'alt-client';
 import mp from '../../shared/mp.js';
-import {ClientPool} from '../ClientPool.js';
+import {ClientPool} from '../pools/ClientPool.js';
 import {_BaseObject} from './BaseObject.js';
 import natives from 'natives';
 import {_VirtualEntityBase} from './VirtualEntityBase';
@@ -12,6 +12,7 @@ import {getOverlayColorType, hashIfNeeded, mpDimensionToAlt, toAlt, toMp} from '
 import {_LocalVehicle} from './Vehicle';
 import {_Entity} from './Entity';
 import {BaseObjectType} from '../../shared/BaseObjectType';
+import { PedPool } from '../pools/PedPool.js';
 
 const view = EntityGetterView.fromClass(alt.Ped, [BaseObjectType.Ped, BaseObjectType.LocalPed]);
 
@@ -848,7 +849,7 @@ Object.defineProperty(alt.LocalPed.prototype, 'mp', {
 
 mp.Ped = _Ped;
 
-mp.peds = new ClientPool(view, [_Ped, _LocalPed]);
+mp.peds = new PedPool(view, [_Ped, _LocalPed]);
 
 mp.peds.new = function (model, position, heading = 0, dimension = 0) {
     mp.notifyTrace('entity', 'creating local ped', model, position);

--- a/bindings/src/client/entities/Pickup.js
+++ b/bindings/src/client/entities/Pickup.js
@@ -1,6 +1,6 @@
 import mp from '../../shared/mp';
 import {_WorldObject} from './WorldObject';
-import { ClientPool } from '../ClientPool';
+import { ClientPool } from '../pools/ClientPool';
 import {EntityStoreView} from '../../shared/pools/EntityStoreView';
 
 export class _Pickup extends _WorldObject {

--- a/bindings/src/client/entities/Player.js
+++ b/bindings/src/client/entities/Player.js
@@ -1,7 +1,7 @@
 import * as alt from 'alt-client';
 import * as natives from 'natives';
 import mp from '../../shared/mp.js';
-import {ClientPool} from '../ClientPool.js';
+import {ClientPool} from '../pools/ClientPool.js';
 import {_Entity} from './Entity.js';
 import {altSeatToMp, getOverlayColorType, internalName, toMp} from '../../shared/utils';
 import {EntityGetterView} from '../../shared/pools/EntityGetterView';

--- a/bindings/src/client/entities/Vehicle.js
+++ b/bindings/src/client/entities/Vehicle.js
@@ -1,7 +1,7 @@
 import * as alt from 'alt-client';
 import * as natives from 'natives';
 import mp from '../../shared/mp.js';
-import { ClientPool } from '../ClientPool.js';
+import { ClientPool } from '../pools/ClientPool.js';
 import { _Entity } from './Entity.js';
 import { _Colshape } from './Colshape';
 import {VirtualEntityID} from '../../shared/VirtualEntityID';
@@ -10,6 +10,7 @@ import {EntityStoreView} from '../../shared/pools/EntityStoreView';
 import {EntityMixedView} from '../../shared/pools/EntityMixedView';
 import {hashIfNeeded, mpDimensionToAlt, toAlt, toMp} from '../../shared/utils';
 import {BaseObjectType} from '../../shared/BaseObjectType';
+import { VehiclePool } from '../pools/VehiclePool.js';
 
 /** @type {Record<string, string>} */
 const keys = {'handlingnamehash':'handlingNameHash','mass':'mass','initialdragcoeff':'initialDragCoeff','downforcemodifier':'downforceModifier','unkfloat1':'unkFloat1','unkfloat2':'unkFloat2','centreofmassoffset':'centreOfMassOffset','inertiamultiplier':'inertiaMultiplier','percentsubmerged':'percentSubmerged','percentsubmergedratio':'percentSubmergedRatio','drivebiasfront':'driveBiasFront','acceleration':'acceleration','initialdrivegears':'initialDriveGears','driveinertia':'driveInertia','clutchchangeratescaleupshift':'clutchChangeRateScaleUpShift','clutchchangeratescaledownshift':'clutchChangeRateScaleDownShift','initialdriveforce':'initialDriveForce','drivemaxflatvel':'driveMaxFlatVel','initialdrivemaxflatvel':'initialDriveMaxFlatVel','brakeforce':'brakeForce','unkfloat4':'unkFloat4','brakebiasfront':'brakeBiasFront','brakebiasrear':'brakeBiasRear','handbrakeforce':'handBrakeForce','steeringlock':'steeringLock','steeringlockratio':'steeringLockRatio','tractioncurvemax':'tractionCurveMax','tractioncurvemaxratio':'tractionCurveMaxRatio','tractioncurvemin':'tractionCurveMin','tractioncurveminratio':'tractionCurveMinRatio','tractioncurvelateral':'tractionCurveLateral','tractioncurvelateralratio':'tractionCurveLateralRatio','tractionspringdeltamax':'tractionSpringDeltaMax','tractionspringdeltamaxratio':'tractionSpringDeltaMaxRatio','lowspeedtractionlossmult':'lowSpeedTractionLossMult','camberstiffness':'camberStiffness','tractionbiasfront':'tractionBiasFront','tractionbiasrear':'tractionBiasRear','tractionlossmult':'tractionLossMult','suspensionforce':'suspensionForce','suspensioncompdamp':'suspensionCompDamp','suspensionrebounddamp':'suspensionReboundDamp','suspensionupperlimit':'suspensionUpperLimit','suspensionlowerlimit':'suspensionLowerLimit','suspensionraise':'suspensionRaise','suspensionbiasfront':'suspensionBiasFront','suspensionbiasrear':'suspensionBiasRear','antirollbarforce':'antiRollBarForce','antirollbarbiasfront':'antiRollBarBiasFront','antirollbarbiasrear':'antiRollBarBiasRear','rollcentreheightfront':'rollCentreHeightFront','rollcentreheightrear':'rollCentreHeightRear','collisiondamagemult':'collisionDamageMult','weapondamagemult':'weaponDamageMult','deformationdamagemult':'deformationDamageMult','enginedamagemult':'engineDamageMult','petroltankvolume':'petrolTankVolume','oilvolume':'oilVolume','unkfloat5':'unkFloat5','seatoffsetdistx':'seatOffsetDistX','seatoffsetdisty':'seatOffsetDistY','seatoffsetdistz':'seatOffsetDistZ','monetaryvalue':'monetaryValue','modelflags':'modelFlags','handlingflags':'handlingFlags','damageflags':'damageFlags'};
@@ -511,7 +512,7 @@ Object.defineProperty(alt.LocalVehicle.prototype, 'mp', {
 
 mp.Vehicle = _Vehicle;
 
-mp.vehicles = new ClientPool(view, [_Vehicle, _LocalVehicle]);
+mp.vehicles = new VehiclePool(view, [_Vehicle, _LocalVehicle]);
 
 const initializers = {};
 

--- a/bindings/src/client/entities/label/Label.js
+++ b/bindings/src/client/entities/label/Label.js
@@ -1,7 +1,7 @@
 import * as alt from 'alt-client';
 import * as natives from 'natives';
 import mp from '../../../shared/mp.js';
-import { ClientPool } from '../../ClientPool';
+import { ClientPool } from '../../pools/ClientPool.js';
 import { _Entity } from '../Entity';
 import { LabelRenderer } from './LabelRenderer';
 import { VirtualEntityID } from '../../../shared/VirtualEntityID';

--- a/bindings/src/client/pools/ClientPool.js
+++ b/bindings/src/client/pools/ClientPool.js
@@ -1,5 +1,4 @@
-import { SharedPool } from '../shared/SharedPool';
-import { vdist2 } from '../shared/utils';
+import { SharedPool } from '../../shared/SharedPool';
 
 export class ClientPool extends SharedPool {
     /** @type {EntityBaseView} */

--- a/bindings/src/client/pools/PedPool.js
+++ b/bindings/src/client/pools/PedPool.js
@@ -1,0 +1,17 @@
+import alt from 'alt-client';
+import { ClientPool } from './ClientPool.js';
+
+export class PedPool extends ClientPool {
+    exists(ped) {
+        if (ped == null) return false;
+
+        if (typeof ped === 'object') {
+            if (ped.alt instanceof alt.Ped) {
+                return ped.alt.valid;
+            }
+            return false;
+        }
+
+        return super.exists(ped);
+    }
+}

--- a/bindings/src/client/pools/PlayerPool.js
+++ b/bindings/src/client/pools/PlayerPool.js
@@ -1,0 +1,16 @@
+import alt from 'alt-client';
+import { ClientPool } from './ClientPool.js';
+
+export class PlayerPool extends ClientPool {
+
+    exists(player) {
+        if (player == null) return false;
+
+        if (typeof player === 'object') {
+            if (player.alt instanceof alt.Player) return player.alt.valid;
+            return false;
+        }
+
+        return super.exists(player);
+    }
+}

--- a/bindings/src/client/pools/VehiclePool.js
+++ b/bindings/src/client/pools/VehiclePool.js
@@ -1,0 +1,17 @@
+import alt from 'alt-client';
+import { ClientPool } from './ClientPool.js';
+
+export class VehiclePool extends ClientPool {
+    exists(vehicle) {
+        if (vehicle == null) return false;
+
+        if (typeof vehicle === 'object') {
+            if (vehicle.alt instanceof alt.Vehicle) {
+                return vehicle.alt.valid;
+            }
+            return false;
+        }
+
+        return super.exists(vehicle);
+    }
+}

--- a/bindings/src/client/pools/index.js
+++ b/bindings/src/client/pools/index.js
@@ -1,0 +1,3 @@
+import './ClientPool.js';
+import './VehiclePool.js';
+import './PedPool.js';

--- a/bindings/src/server/entities/Ped.js
+++ b/bindings/src/server/entities/Ped.js
@@ -5,6 +5,7 @@ import { _Entity } from './Entity.js';
 import { ServerPool } from '../pools/ServerPool';
 import {EntityGetterView} from '../../shared/pools/EntityGetterView';
 import {BaseObjectType} from '../../shared/BaseObjectType';
+import { PedPool } from '../pools/PedPool.js';
 
 export class _Ped extends _Entity {
     alt;
@@ -45,7 +46,7 @@ Object.defineProperty(alt.Ped.prototype, 'mp', {
 
 mp.Ped = _Ped;
 
-mp.peds = new ServerPool(EntityGetterView.fromClass(alt.Ped, [BaseObjectType.Ped]), [_Ped], 4);
+mp.peds = new PedPool(EntityGetterView.fromClass(alt.Ped, [BaseObjectType.Ped]), [_Ped], 4);
 
 mp.peds.new = function(model, position, params) {
     model = hashIfNeeded(model);

--- a/bindings/src/server/entities/Vehicle.js
+++ b/bindings/src/server/entities/Vehicle.js
@@ -6,6 +6,7 @@ import {_Entity} from './Entity.js';
 import {ServerPool} from '../pools/ServerPool';
 import {EntityGetterView} from '../../shared/pools/EntityGetterView';
 import {BaseObjectType} from '../../shared/BaseObjectType';
+import {VehiclePool} from '../pools/VehiclePool.js';
 
 export class _Vehicle extends _Entity {
     /** @type {import('alt-server').Vehicle} */
@@ -355,7 +356,7 @@ Object.defineProperty(alt.Vehicle.prototype, 'mp', {
 
 mp.Vehicle = _Vehicle;
 
-mp.vehicles = new ServerPool(EntityGetterView.fromClass(alt.Vehicle, [BaseObjectType.Vehicle]), [_Vehicle], 2);
+mp.vehicles = new VehiclePool(EntityGetterView.fromClass(alt.Vehicle, [BaseObjectType.Vehicle]), [_Vehicle], 2);
 
 mp.vehicles.new = function(model, position, options = {}) {
     model = hashIfNeeded(model);

--- a/bindings/src/server/pools/PedPool.js
+++ b/bindings/src/server/pools/PedPool.js
@@ -1,0 +1,17 @@
+import alt from 'alt-server';
+import { ServerPool } from './ServerPool.js';
+
+export class PedPool extends ServerPool {
+    exists(ped) {
+        if (ped == null) return false;
+
+        if (typeof ped === 'object') {
+            if (ped.alt instanceof alt.Ped) {
+                return ped.alt.valid;
+            }
+            return false;
+        }
+
+        return super.exists(ped);
+    }
+}

--- a/bindings/src/server/pools/PlayerPool.js
+++ b/bindings/src/server/pools/PlayerPool.js
@@ -1,6 +1,5 @@
 import alt from 'alt-server';
 import { ServerPool } from './ServerPool.js';
-import mp from 'shared/mp';
 import { InternalChat } from 'shared/DefaultChat.js';
 import {argsToAlt, mpDimensionToAlt} from 'shared/utils';
 import {emitAllClients, emitAllClientsUnreliable, emitClient, emitClientUnreliable} from '../serverUtils';
@@ -8,6 +7,17 @@ import {emitAllClients, emitAllClientsUnreliable, emitClient, emitClientUnreliab
 export class PlayerPool extends ServerPool {
     broadcast(text) {
         InternalChat.broadcast(text);
+    }
+
+    exists(player) {
+        if (player == null) return false;
+
+        if (typeof player === 'object') {
+            if (player.alt instanceof alt.Player) return player.alt.valid;
+            return false;
+        }
+
+        return super.exists(player);
     }
 
     //mp.players.call(String eventName[, Array Arguments]);

--- a/bindings/src/server/pools/VehiclePool.js
+++ b/bindings/src/server/pools/VehiclePool.js
@@ -1,0 +1,17 @@
+import alt from 'alt-server';
+import { ServerPool } from './ServerPool.js';
+
+export class VehiclePool extends ServerPool {
+    exists(vehicle) {
+        if (vehicle == null) return false;
+
+        if (typeof vehicle === 'object') {
+            if (vehicle.alt instanceof alt.Vehicle) {
+                return vehicle.alt.valid;
+            }
+            return false;
+        }
+
+        return super.exists(vehicle);
+    }
+}

--- a/bindings/src/server/pools/index.js
+++ b/bindings/src/server/pools/index.js
@@ -1,2 +1,4 @@
 import './ServerPool.js';
 import './PlayerPool.js';
+import './VehiclePool.js';
+import './PedPool.js';


### PR DESCRIPTION
**Issue Identified**: Standard Existence Checks in `mp.pool.exists` Are Slow

**Details**:
- The standard method for checking the existence of various elements using `mp.Pool.exists` was identified to be slow.
- This issue particularly impacted the most commonly used existence checks, which include checks for:
  - Vehicles
  - Players
  - Peds

**Solution Implemented**:
- Specific existence checks for the aforementioned elements (vehicles, players, and peds) were developed.
- These specialized checks operate several times faster than the previous standard method.