### PR TITLE
Refactor getVariable method to return null instead of undefined

### DIFF
--- a/bindings/src/client/entities/Colshape.js
+++ b/bindings/src/client/entities/Colshape.js
@@ -131,7 +131,7 @@ function getServerColshape(id, position, dimension, type, meta) {
         remoteId: id,
         shapeType: type,
         getVariable(key) {
-            return meta[key];
+            return meta[key] ?? null;
         },
         hasVariable(key) {
             return key in meta;

--- a/bindings/src/client/entities/Object.js
+++ b/bindings/src/client/entities/Object.js
@@ -36,8 +36,8 @@ export class _Object extends _Entity {
     type = 'object';
 
     getVariable(key) {
-        if (!this.hasVariable(key)) return undefined;
-        return toMp(this.alt.getMeta(key));
+        if (!this.hasVariable(key)) return null;
+        return toMp(this.alt.getMeta(key)) ?? null;
     }
 
     hasVariable(key) {
@@ -209,8 +209,8 @@ export class _NetworkObject extends _Object {
     }
 
     getVariable(key) {
-        if (!this.hasVariable(key)) return undefined;
-        return toMp(this.alt.getStreamSyncedMeta(key));
+        if (!this.hasVariable(key)) return null;
+        return toMp(this.alt.getStreamSyncedMeta(key)) ?? null;
     }
 
     hasVariable(key) {

--- a/bindings/src/client/entities/Ped.js
+++ b/bindings/src/client/entities/Ped.js
@@ -821,8 +821,8 @@ export class _LocalPed extends _Ped {
     }
 
     getVariable(key) {
-        if (!this.hasVariable(key)) return undefined;
-        return toMp(this.alt.getMeta(key));
+        if (!this.hasVariable(key)) return null;
+        return toMp(this.alt.getMeta(key)) ?? null;
     }
 
     setVariable(key, value) {

--- a/bindings/src/client/entities/Player.js
+++ b/bindings/src/client/entities/Player.js
@@ -19,8 +19,8 @@ export class _Player extends _Entity {
     }
 
     getVariable(key) {
-        if (!this.alt.valid) return undefined;
-        if (this.alt === alt.Player.local && alt.hasLocalMeta(key)) return toMp(alt.getLocalMeta(key));
+        if (!this.alt.valid) return null;
+        if (this.alt === alt.Player.local && alt.hasLocalMeta(key)) return toMp(alt.getLocalMeta(key)) ?? null;
         return super.getVariable(key);
     }
 

--- a/bindings/src/client/entities/Vehicle.js
+++ b/bindings/src/client/entities/Vehicle.js
@@ -524,8 +524,8 @@ export class _LocalVehicle extends _Vehicle {
     // TODO: override natives to use pos setter
 
     getVariable(key) {
-        if (!this.hasVariable(key)) return undefined;
-        return toMp(this.alt.getMeta(key));
+        if (!this.hasVariable(key)) return null;
+        return toMp(this.alt.getMeta(key)) ?? null;
     }
 
     setVariable(key, value) {

--- a/bindings/src/client/entities/WorldObject.js
+++ b/bindings/src/client/entities/WorldObject.js
@@ -14,10 +14,10 @@ export class _WorldObject extends _BaseObject {
     }
 
     getVariable(key) {
-        if (!this.alt.valid) return undefined;
-        if (this.#alt.getStreamSyncedMeta && this.#alt.hasStreamSyncedMeta(key)) return toMp(this.#alt.getStreamSyncedMeta(key));
-        if (this.#alt.hasSyncedMeta(key)) return toMp(this.#alt.getSyncedMeta(key));
-        return undefined;
+        if (!this.alt.valid) return null;
+        if (this.#alt.getStreamSyncedMeta && this.#alt.hasStreamSyncedMeta(key)) return toMp(this.#alt.getStreamSyncedMeta(key)) ?? null;
+        if (this.#alt.hasSyncedMeta(key)) return toMp(this.#alt.getSyncedMeta(key)) ?? null;
+        return null;
     }
 
     hasVariable(key) {

--- a/bindings/src/client/entities/label/Label.js
+++ b/bindings/src/client/entities/label/Label.js
@@ -48,12 +48,12 @@ export class _Label extends _VirtualEntityBase {
 
     getVariable(key) {
         if (this.alt.isRemote) {
-            if (!this.alt.hasStreamSyncedMeta(key)) return undefined;
-            return toMp(this.alt.getStreamSyncedMeta(key));
+            if (!this.alt.hasStreamSyncedMeta(key)) return null;
+            return toMp(this.alt.getStreamSyncedMeta(key)) ?? null;
         }
 
-        if (!this.alt.hasMeta(key)) return undefined;
-        return toMp(this.alt.getMeta(key));
+        if (!this.alt.hasMeta(key)) return null;
+        return toMp(this.alt.getMeta(key)) ?? null;
     }
 
     setVariable(key, value) {

--- a/bindings/src/server/entities/Colshape.js
+++ b/bindings/src/server/entities/Colshape.js
@@ -45,8 +45,8 @@ export class _Colshape extends _WorldObject {
     }
 
     getVariable(key) {
-        if (!this.hasVariable(key)) return undefined;
-        return toMp(this.alt.getMeta(key));
+        if (!this.hasVariable(key)) return null;
+        return toMp(this.alt.getMeta(key)) ?? null;
     }
 
     destroy() {

--- a/bindings/src/server/entities/Dummy.js
+++ b/bindings/src/server/entities/Dummy.js
@@ -27,7 +27,7 @@ class _MpEntity {
     }
 
     getVariable(key) {
-        return toMp(this.#meta[key]);
+        return toMp(this.#meta[key]) ?? null;
     }
 
     hasVariable(key) {

--- a/bindings/src/server/entities/Entity.js
+++ b/bindings/src/server/entities/Entity.js
@@ -33,9 +33,9 @@ export class _Entity extends _WorldObject {
     }
 
     getStreamVariable(key) {
-        if (!mp._shareVariablesBetweenResources) return this.#streamVariableCache.get(key);
-        if (!this.hasStreamVariable(key)) return undefined;
-        return toMp(this.#alt.getStreamSyncedMeta(key));
+        if (!mp._shareVariablesBetweenResources) return this.#streamVariableCache.get(key) ?? null;
+        if (!this.hasStreamVariable(key)) return null;
+        return toMp(this.#alt.getStreamSyncedMeta(key)) ?? null;
     }
 
     hasStreamVariable(key) {

--- a/bindings/src/server/entities/WorldObject.js
+++ b/bindings/src/server/entities/WorldObject.js
@@ -53,17 +53,17 @@ export class _WorldObject extends _BaseObject {
 
     getVariable(key) {
         if (!mp._shareVariablesBetweenResources)
-            return this.#variableCache.get(key);
+            return this.#variableCache.get(key) ?? null;
 
-        if (!this.hasVariable(key)) return undefined;
+        if (!this.hasVariable(key)) return null;
 
         if (this.#alt.hasLocalMeta && this.#alt.hasLocalMeta(key))
-            return toMp(this.#alt.getLocalMeta(key));
+            return toMp(this.#alt.getLocalMeta(key)) ?? null;
 
         if (!mp._syncedMeta && this.#alt.getStreamSyncedMeta)
-            return toMp(this.#alt.getStreamSyncedMeta(key));
+            return toMp(this.#alt.getStreamSyncedMeta(key)) ?? null;
 
-        return toMp(this.#alt.getSyncedMeta(key));
+        return toMp(this.#alt.getSyncedMeta(key)) ?? null;
     }
 
     hasVariable(key) {


### PR DESCRIPTION
In short:
In RAGE:MP if a variable is not defined then the function return null not undefined. So if someone want to compare in strict this will be cause bugs.