### PR TITLE
fix: getVariable return type in client-side

### DIFF
--- a/bindings/src/client/entities/Colshape.js
+++ b/bindings/src/client/entities/Colshape.js
@@ -131,7 +131,7 @@ function getServerColshape(id, position, dimension, type, meta) {
         remoteId: id,
         shapeType: type,
         getVariable(key) {
-            return meta[key] ?? null;
+            return meta[key];
         },
         hasVariable(key) {
             return key in meta;

--- a/bindings/src/client/entities/Object.js
+++ b/bindings/src/client/entities/Object.js
@@ -36,7 +36,7 @@ export class _Object extends _Entity {
     type = 'object';
 
     getVariable(key) {
-        if (!this.hasVariable(key)) return undefined;
+        if (!this.hasVariable(key)) return;
         return toMp(this.alt.getMeta(key));
     }
 
@@ -209,7 +209,7 @@ export class _NetworkObject extends _Object {
     }
 
     getVariable(key) {
-        if (!this.hasVariable(key)) return undefined;
+        if (!this.hasVariable(key)) return;
         return toMp(this.alt.getStreamSyncedMeta(key));
     }
 

--- a/bindings/src/client/entities/Object.js
+++ b/bindings/src/client/entities/Object.js
@@ -36,8 +36,8 @@ export class _Object extends _Entity {
     type = 'object';
 
     getVariable(key) {
-        if (!this.hasVariable(key)) return null;
-        return toMp(this.alt.getMeta(key)) ?? null;
+        if (!this.hasVariable(key)) return undefined;
+        return toMp(this.alt.getMeta(key));
     }
 
     hasVariable(key) {
@@ -209,8 +209,8 @@ export class _NetworkObject extends _Object {
     }
 
     getVariable(key) {
-        if (!this.hasVariable(key)) return null;
-        return toMp(this.alt.getStreamSyncedMeta(key)) ?? null;
+        if (!this.hasVariable(key)) return undefined;
+        return toMp(this.alt.getStreamSyncedMeta(key));
     }
 
     hasVariable(key) {

--- a/bindings/src/client/entities/Ped.js
+++ b/bindings/src/client/entities/Ped.js
@@ -821,7 +821,7 @@ export class _LocalPed extends _Ped {
     }
 
     getVariable(key) {
-        if (!this.hasVariable(key)) return undefined;
+        if (!this.hasVariable(key)) return;
         return toMp(this.alt.getMeta(key));
     }
 

--- a/bindings/src/client/entities/Ped.js
+++ b/bindings/src/client/entities/Ped.js
@@ -821,8 +821,8 @@ export class _LocalPed extends _Ped {
     }
 
     getVariable(key) {
-        if (!this.hasVariable(key)) return null;
-        return toMp(this.alt.getMeta(key)) ?? null;
+        if (!this.hasVariable(key)) return undefined;
+        return toMp(this.alt.getMeta(key));
     }
 
     setVariable(key, value) {

--- a/bindings/src/client/entities/Player.js
+++ b/bindings/src/client/entities/Player.js
@@ -19,7 +19,7 @@ export class _Player extends _Entity {
     }
 
     getVariable(key) {
-        if (!this.alt.valid) return undefined;
+        if (!this.alt.valid) return;
         if (this.alt === alt.Player.local && alt.hasLocalMeta(key)) return toMp(alt.getLocalMeta(key));
         return super.getVariable(key);
     }

--- a/bindings/src/client/entities/Player.js
+++ b/bindings/src/client/entities/Player.js
@@ -19,8 +19,8 @@ export class _Player extends _Entity {
     }
 
     getVariable(key) {
-        if (!this.alt.valid) return null;
-        if (this.alt === alt.Player.local && alt.hasLocalMeta(key)) return toMp(alt.getLocalMeta(key)) ?? null;
+        if (!this.alt.valid) return undefined;
+        if (this.alt === alt.Player.local && alt.hasLocalMeta(key)) return toMp(alt.getLocalMeta(key));
         return super.getVariable(key);
     }
 

--- a/bindings/src/client/entities/Vehicle.js
+++ b/bindings/src/client/entities/Vehicle.js
@@ -524,7 +524,7 @@ export class _LocalVehicle extends _Vehicle {
     // TODO: override natives to use pos setter
 
     getVariable(key) {
-        if (!this.hasVariable(key)) return undefined;
+        if (!this.hasVariable(key)) return;
         return toMp(this.alt.getMeta(key));
     }
 

--- a/bindings/src/client/entities/Vehicle.js
+++ b/bindings/src/client/entities/Vehicle.js
@@ -524,8 +524,8 @@ export class _LocalVehicle extends _Vehicle {
     // TODO: override natives to use pos setter
 
     getVariable(key) {
-        if (!this.hasVariable(key)) return null;
-        return toMp(this.alt.getMeta(key)) ?? null;
+        if (!this.hasVariable(key)) return undefined;
+        return toMp(this.alt.getMeta(key));
     }
 
     setVariable(key, value) {

--- a/bindings/src/client/entities/WorldObject.js
+++ b/bindings/src/client/entities/WorldObject.js
@@ -14,10 +14,10 @@ export class _WorldObject extends _BaseObject {
     }
 
     getVariable(key) {
-        if (!this.alt.valid) return null;
+        if (!this.alt.valid) return undefined;
         if (this.#alt.getStreamSyncedMeta && this.#alt.hasStreamSyncedMeta(key)) return toMp(this.#alt.getStreamSyncedMeta(key)) ?? null;
-        if (this.#alt.hasSyncedMeta(key)) return toMp(this.#alt.getSyncedMeta(key)) ?? null;
-        return null;
+        if (this.#alt.hasSyncedMeta(key)) return toMp(this.#alt.getSyncedMeta(key));
+        return undefined;
     }
 
     hasVariable(key) {

--- a/bindings/src/client/entities/WorldObject.js
+++ b/bindings/src/client/entities/WorldObject.js
@@ -14,10 +14,9 @@ export class _WorldObject extends _BaseObject {
     }
 
     getVariable(key) {
-        if (!this.alt.valid) return undefined;
-        if (this.#alt.getStreamSyncedMeta && this.#alt.hasStreamSyncedMeta(key)) return toMp(this.#alt.getStreamSyncedMeta(key)) ?? null;
+        if (!this.alt.valid) return;
+        if (this.#alt.getStreamSyncedMeta && this.#alt.hasStreamSyncedMeta(key)) return toMp(this.#alt.getStreamSyncedMeta(key));
         if (this.#alt.hasSyncedMeta(key)) return toMp(this.#alt.getSyncedMeta(key));
-        return undefined;
     }
 
     hasVariable(key) {

--- a/bindings/src/client/entities/label/Label.js
+++ b/bindings/src/client/entities/label/Label.js
@@ -48,12 +48,12 @@ export class _Label extends _VirtualEntityBase {
 
     getVariable(key) {
         if (this.alt.isRemote) {
-            if (!this.alt.hasStreamSyncedMeta(key)) return null;
-            return toMp(this.alt.getStreamSyncedMeta(key)) ?? null;
+            if (!this.alt.hasStreamSyncedMeta(key)) return undefined;
+            return toMp(this.alt.getStreamSyncedMeta(key));
         }
 
-        if (!this.alt.hasMeta(key)) return null;
-        return toMp(this.alt.getMeta(key)) ?? null;
+        if (!this.alt.hasMeta(key)) return undefined;
+        return toMp(this.alt.getMeta(key));
     }
 
     setVariable(key, value) {

--- a/bindings/src/client/entities/label/Label.js
+++ b/bindings/src/client/entities/label/Label.js
@@ -48,7 +48,7 @@ export class _Label extends _VirtualEntityBase {
 
     getVariable(key) {
         if (this.alt.isRemote) {
-            if (!this.alt.hasStreamSyncedMeta(key)) return undefined;
+            if (!this.alt.hasStreamSyncedMeta(key)) return;
             return toMp(this.alt.getStreamSyncedMeta(key));
         }
 


### PR DESCRIPTION
A few days ago I made a commit (9a2afee7544ef0359dd1cfe5bad7d062454e92ce) where I explained that the `getVariable` method returns null if it is not defined, but in client-side this will return undefined.

This commit is just a reverse of client src