### PR TITLE
fix: missing default p2 bool in getPedInSeat

### DIFF
--- a/bindings/src/client/entities/Vehicle.js
+++ b/bindings/src/client/entities/Vehicle.js
@@ -335,7 +335,7 @@ export class _Vehicle extends _Entity {
         return this.setTaskGotoPlaneMinHeightAboveTerrain;
     }
 
-    getPedInSeat(seatIndex, p2) {
+    getPedInSeat(seatIndex, p2 = false) {
         return natives.getPedInVehicleSeat(this.handle, seatIndex, p2);
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ragemp-altv-bridge",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "description": "RAGE Multiplayer alt:V Bridge. This package provides a bridge between RAGE Multiplayer and alt:V. It allows you to use RAGEMP code in alt:V.",
     "keywords": [
         "ragemp",


### PR DESCRIPTION
Fixed issue when getPedInSeat native didn't work properly