### PR TITLE
Fix/enter leave vehicle events

### DIFF
--- a/bindings/src/shared/utils.js
+++ b/bindings/src/shared/utils.js
@@ -135,6 +135,10 @@ export const altSeatToMp = (altSeat) => {
     return altSeat - 1;
 };
 
+export const altSeatToClientMp = (altSeat) => {
+    return altSeat - 2;
+};
+
 export const mpSeatToAlt = (mpSeat) => {
     return mpSeat + 1;
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ragemp-altv-bridge",
-    "version": "1.0.4",
+    "version": "1.0.3",
     "description": "RAGE Multiplayer alt:V Bridge. This package provides a bridge between RAGE Multiplayer and alt:V. It allows you to use RAGEMP code in alt:V.",
     "keywords": [
         "ragemp",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ragemp-altv-bridge",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "description": "RAGE Multiplayer alt:V Bridge. This package provides a bridge between RAGE Multiplayer and alt:V. It allows you to use RAGEMP code in alt:V.",
     "keywords": [
         "ragemp",


### PR DESCRIPTION
Optimized vehicle enter/leave events. Before they used to be on timers, now they are made using only alt:V events.
Also fixed seats ids on client-side. Client-side RAGEMP have -1 as driver, and Server-Side as 0 for Driver. 